### PR TITLE
Fix three critical code bugs

### DIFF
--- a/src/components/paginaPrincipal.tsx
+++ b/src/components/paginaPrincipal.tsx
@@ -19,6 +19,11 @@ const useBackgroundRotation = (images: string[], interval: number = 5000) => {
     return () => clearInterval(timer);
   }, [images.length, interval]);
 
+  // Garantir que o índice atual permaneça dentro do intervalo quando o conjunto de imagens muda
+  useEffect(() => {
+    setCurrentImageIndex((prevIndex) => (images.length === 0 ? 0 : prevIndex % images.length))
+  }, [images.length])
+
   return images[currentImageIndex];
 };
 

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
@@ -16,9 +16,9 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+        <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
           Return to Home
-        </a>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
Fix three bugs: prevent `useToast` listener re-subscription to avoid memory leaks, clamp background image index to prevent out-of-bounds errors, and use SPA navigation in `NotFound` for better UX.

---
<a href="https://cursor.com/background-agent?bcId=bc-0986609f-f5c9-4551-8e0a-ccbb4507118e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0986609f-f5c9-4551-8e0a-ccbb4507118e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

